### PR TITLE
Change format behaviour

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -71,16 +71,18 @@ JsonViewEngine.prototype.renderObject = function (viewObj, data, settings, useCa
 		var source = options.from || attr;
 		var value = extract(data, source);
 
-		if (options.view && _.isObject(value)) {
-			var path = Path.resolve(Path.join(settings.views, options.view + '.json'));
-			value = self.render(path, value, settings, useCache);
-
-		} else if (options.format) {
+		//Allow data format/parse/fetch before sending to view.
+		if (options.format) {
 			var formatFunction = self.helpers[options.format];
 			if (formatFunction && _.isFunction(formatFunction)) {
 				value = formatFunction.call(self.helpers, value, data);
 			}
 		}
+		
+		if (options.view && _.isObject(value)) {
+			var path = Path.resolve(Path.join(settings.views, options.view + '.json'));
+			value = self.render(path, value, settings, useCache);
+		}  
 
 		return value;
 	});


### PR DESCRIPTION
With this change I intend to allow data to be formatted before sending to view.

Use case:
1- Sequelize model has relation with children
2- Children comes from a accessory method getChildren()
3- In the formatter its called the accessory method above, that returns all data (already working)
4- Now that the data is returned, I want to send it to another view, to be rendered accordingly

The step 4 in the default version doesn't work, because you can either format or render another view.
With my change, the formatter is called, and then the view is called to render the child.